### PR TITLE
Updated formio import

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var React = require('react');
-var formiojs = require('formiojs')();
+var formiojs = require('formiojs');
 var FormioComponent = require('./FormioComponent');
 
 require('./components');


### PR DESCRIPTION
The way to import formiojs [has changed](https://github.com/formio/formio.js/commit/0d8aeda555af13edb6d5271e3cdd7ccb93a4f701)

(It would be best if we published formio.js to npm and used that instead of a git url to master)