### PR TITLE
Update React & one fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "global:React"
   },
   "dependencies": {
-    "formiojs": "git+https://github.com/formio/formio.js.git",
+    "formiojs": "formio/formio.js",
     "moment": "^2.10.6",
     "react": "^0.13.3",
     "react-input-mask": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-formio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React rendering library for form.io embedded forms.",
   "main": "dist/build/Formio.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
   "dependencies": {
     "formiojs": "formio/formio.js",
     "moment": "^2.10.6",
-    "react": "^0.13.3",
-    "react-input-mask": "^0.3.0",
-    "react-signature-pad": "0.0.3",
-    "react-widgets": "^2.8.2"
+    "react-input-mask": "^0.6.7",
+    "react-signature-pad": "0.0.5",
+    "react-widgets": "^3.3.1"
   },
   "devDependencies": {
     "babelify": "^6.3.0",
@@ -49,9 +48,15 @@
     "gulp-rename": "^1.2.2",
     "gulp-streamify": "^1.0.2",
     "gulp-uglify": "^1.4.1",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "react-transform-catch-errors": "^1.0.0",
     "reactify": "^1.1.1",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.4.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var Formio = require('./Formio');
 
 var Demo = React.createClass({
@@ -53,7 +54,7 @@ var Demo = React.createClass({
   }
 });
 
-React.render(
+ReactDOM.render(
   <Demo />
   , document.getElementById('formio')
 );

--- a/src/components/mixins/selectMixin.js
+++ b/src/components/mixins/selectMixin.js
@@ -3,6 +3,39 @@ var React = require('react');
 var DropdownList = require('react-widgets/lib/DropdownList');
 var Multiselect = require('react-widgets/lib/Multiselect');
 
+function defineTransformerOutsideStrictMode () {
+    var safeGlobalName = '____formioSelectMixinGetTransformer';
+    var globalObject = typeof window !== 'undefined'
+                            ? window
+                            : typeof global !== "undefined"
+                                ? global
+                                : {};
+
+    /* We are essentially doing this, but because we're in strict mode by default in all babeled
+     * modules, we need to escape it
+     *
+     * //string-replace callback, called for every match in the template.
+     * function transform (_, expression) {
+     *  //bring the properties of "props" into local scope so that the expression can reference them
+     *  with (props) {
+     *    return eval(expression); //evaluate the expression.
+     *  }
+     * }
+     */
+
+    //This escapes strict mode.
+    (1,eval)('function '+safeGlobalName+' (props) { return function (_, exp) { with(props) { return eval(exp); } } }');
+
+    var ret = eval(safeGlobalName);
+
+    //cleanup
+    delete globalObject[safeGlobalName];
+
+    return ret;
+}
+
+var getTransformer = defineTransformerOutsideStrictMode();
+
 module.exports = {
   getInitialState: function() {
     return {
@@ -58,12 +91,7 @@ module.exports = {
       render: function () {
         var props = this.props;
 
-        //string-replace callback, called for every match in the template.
-        function transform (fullMatch, expression) {
-          with (props) { //bring the properties of "props" into local scope so that the expression can reference them
-            return eval(expression); //evaluate the expression.
-          }
-        }
+        var transform = getTransformer(props);
 
         if (props.item) {
           //find all {{ }} expression blocks and then replace the blocks with their evaluation.


### PR DESCRIPTION
I should have split this into two, but I was already deep in when I noticed the strict mode bug.

I wanted to jump in and update react for you. So this primarily does that.

However, my previous pull request had a hidden bug because all modules are marked strict by default. There is a fix for that in here as well.  Once this pull request is merged, I recommend checking out the tag v0.3.0 and testing it through your stack and then publishing it to npm. Then cut a 0.4.0 with the react updates.

The react updates permit React 0.14 and 15.x versions. Giving your component widest possible user base. For projects suck on 0.13 they can continue to use <=0.3 of this component.  