### PR TITLE
Change the column classname to reflect deprecation

### DIFF
--- a/src/components/columns.jsx
+++ b/src/components/columns.jsx
@@ -8,7 +8,7 @@ module.exports = React.createClass({
       <div className="row">
         {this.props.component.columns.map(function(column, index) {
             return (
-              <div key={index} className="col-xs-6">
+              <div key={index} className="col-sm-6">
                 {column.components.map(function(component) {
                   var value = (this.props.data && this.props.data.hasOwnProperty(component.key) ? this.props.data[component.key] : component.defaultValue || '');
                   return (


### PR DESCRIPTION
- In order to reflect bootstrap deprecations in their grid system, i've
changed the classname from col-xs-6 to col-sm-6, also, the angular app
uses this class.