### PR TITLE
Enable component update when isPristine changes

### DIFF
--- a/src/components/FormComponents/mixins/componentMixin.jsx
+++ b/src/components/FormComponents/mixins/componentMixin.jsx
@@ -9,6 +9,11 @@ module.exports = {
       return true;
     }
 
+    // If the pristineness changes without a value change, re-render.
+    if (this.state && this.state.hasOwnProperty('isPristine') && this.state.isPristine !== nextState.isPristine) {
+      return true;
+    }
+    
     // If a new value is passed in, re-render.
     if (this.props.value !== nextProps.value) {
       return true;


### PR DESCRIPTION
In cases where form values do not change, but the pristineness does (for example, when the form is submitted without any modifications to the fields), the form components would not update to show any validation errors. This is now corrected with this fix.