### PR TITLE
Fix Day components validation check

### DIFF
--- a/src/components/FormComponents/day.jsx
+++ b/src/components/FormComponents/day.jsx
@@ -26,7 +26,7 @@ module.exports = React.createClass({
       errorMessage: ''
     };
     if (!required) {
-      return true;
+      return state;
     }
     if (!value && required) {
       state = {


### PR DESCRIPTION
Day components were triggering validation errors even when no validation was required. This was because of an inconsistent return value from the `validateCustom` method. This patch fixes this by returning the correct `state` object.