### PR TITLE
Fix issue where forms using url data have headers stripped

### DIFF
--- a/lib/components/FormComponents/select.js
+++ b/lib/components/FormComponents/select.js
@@ -135,15 +135,23 @@ module.exports = _react2.default.createClass({
             this.url = _formiojs2.default.getBaseUrl() + this.props.component.data.url;
           }
 
-          // Disable auth for outgoing requests.
+          // Allow basic auth against 3rd party API's
           if (!this.props.component.authenticate && this.url.indexOf(_formiojs2.default.getBaseUrl()) === -1) {
+
             this.options = {
-              disableJWT: true,
-              headers: {
-                Authorization: undefined,
-                Pragma: undefined,
-                'Cache-Control': undefined
-              }
+              noToken: true,
+              headers: (() => {
+                let headers = new Headers({
+                  'Accept': 'application/json',
+                  'Content-type': 'application/json; charset=UTF-8'
+                });
+                
+                this.props.component.data.headers.forEach((header) => {
+                  headers.append(header.key, header.value)
+                });
+
+                return headers;
+              })()
             };
           }
         } else {
@@ -198,7 +206,7 @@ module.exports = _react2.default.createClass({
 
           // If this is a search, then add that to the filter.
           newUrl += (newUrl.indexOf('?') === -1 ? '?' : '&') + (0, _util.serialize)(_this.options.params);
-          _formiojs2.default.request(newUrl).then(function (data) {
+          _formiojs2.default.request(newUrl, null, null, this.options.headers, { noToken: this.options.noToken }).then(function (data) {
             // If the selectValue prop is defined, use it.
             if (_this.props.component.selectValues) {
               _this.setResult((0, _get2.default)(data, _this.props.component.selectValues, []), append);

--- a/lib/components/FormComponents/select.js
+++ b/lib/components/FormComponents/select.js
@@ -139,7 +139,7 @@ module.exports = _react2.default.createClass({
           if (!this.props.component.authenticate && this.url.indexOf(_formiojs2.default.getBaseUrl()) === -1) {
 
             this.options = {
-              noToken: true,
+              noToken: this.props.component.validate.required,
               headers: (() => {
                 let headers = new Headers({
                   'Accept': 'application/json',


### PR DESCRIPTION
Build headers based on  `this.props.component.data.headers` and pass along to `_formiojs2.default.request`. Along with options for if formio JWT auth should be enabled.