### PR TITLE
Allow adjusting submission while form is being created

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-formio",
-  "version": "2.0.0-beta5",
+  "version": "2.0.1",
   "description": "React renderer for form.io forms.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/Formio.js
+++ b/src/components/Formio.js
@@ -53,12 +53,10 @@ export class Formio extends Component {
   };
 
   initializeFormio = () => {
-    const {submission} = this.props;
-
     if (this.createPromise) {
       this.createPromise.then(() => {
-        if (submission) {
-          this.formio.submission = submission;
+        if (this.props.submission) {
+          this.formio.submission = this.props.submission;
         }
         //this.formio.hideComponents([]); (From Components.js)
         this.formio.on('prevPage', this.emit('onPrevPage'));
@@ -91,7 +89,7 @@ export class Formio extends Component {
       this.initializeFormio();
     }
 
-    if (submission !== nextProps.submission) {
+    if (submission !== nextProps.submission && this.formio) {
       this.formio.submission = nextProps.submission;
     }
   };


### PR DESCRIPTION
Ran into a problem where react-formio causes reference to undefined `this.formio` object when applying submission object while formio is being constructed.

Associated pull request will address the issue and enable update of submission during form creation phase.