### PR TITLE
Allow i18n to be passed as an object

### DIFF
--- a/src/components/Formio.js
+++ b/src/components/Formio.js
@@ -14,7 +14,7 @@ export class Formio extends Component {
     options: PropTypes.shape({
       readOnly: PropTypes.boolean,
       noAlerts: PropTypes.boolean,
-      i18n: PropTypes.string,
+      i18n: PropTypes.object,
       template: PropTypes.string
     }),
     onPrevPage: PropTypes.func,


### PR DESCRIPTION
It should be possible to pass i18n object as an object.