### PR TITLE
Fix #214: Save form without losing all components.

### DIFF
--- a/src/components/FormBuilder.js
+++ b/src/components/FormBuilder.js
@@ -56,9 +56,9 @@ export default class extends Component {
   componentWillReceiveProps = (nextProps) => {
     const {options, form} = this.props;
 
-    if (form !== nextProps.form) {
-      this.initializeBuilder(nextProps);
-    }
+    //if (form !== nextProps.form) {
+    //  this.initializeBuilder(nextProps);
+    //}
 
     if (options !== nextProps.options) {
       this.initializeBuilder(nextProps);


### PR DESCRIPTION
- The problem at hand is that all form components can get dropped completely upon save after edit.
- Testing has revealed that this problem exists in all 3.x versions, but not in any 4.x versions.
- Inspired from pr #222 of issue #208, the following diff between 3.x and 4.x stood out as particularly suspicious:
```
$ git diff -r v3.1.12..v4.0.0-beta.6 -- src/components/FormBuilder.js
diff --git a/src/components/FormBuilder.js b/src/components/FormBuilder.js
index bd516f9..ebe5def 100644
--- a/src/components/FormBuilder.js
+++ b/src/components/FormBuilder.js
[...]
@@ -56,9 +57,9 @@ export default class extends Component {
   componentWillReceiveProps = (nextProps) => {
     const {options, form} = this.props;
 
-    if (form !== nextProps.form) {
-      this.initializeBuilder(nextProps);
-    }
+    // if (form !== nextProps.form) {
+    //   this.initializeBuilder(nextProps);
+    // }
 
     if (options !== nextProps.options) {
       this.initializeBuilder(nextProps);
```
- I have confirmed that this fixes at least [scenario 3](https://github.com/formio/react-formio/issues/214#issuecomment-508111463) (scenarios 1-2 not tested yet).