### PR TITLE
Don't mutate props

### DIFF
--- a/src/components/FormBuilder.jsx
+++ b/src/components/FormBuilder.jsx
@@ -33,7 +33,9 @@ export default class FormBuilder extends Component {
   };
 
   initializeBuilder = (props) => {
-    const {options, form, Builder} = props;
+    const options = Object.assign({}, props.options);
+    const form = Object.assign({}, props.form);
+    const Builder = props.Builder;
 
     if (this.builder !== undefined) {
       this.builder.instance.destroy(true);


### PR DESCRIPTION
The `FormioFormBuilder` constructor mutates the `form` prop passed to it as components are added. This PR clones props before initializing the builder.

It's a bad idea to mutate props to begin with (they're supposed to be immutable). It is also responsible for https://github.com/formio/react-formio/issues/208, https://github.com/formio/react-formio/pull/222, https://github.com/formio/react-formio/issues/228, because line 65 compares `nextProps` to the mutated props rather than the initial props. As a result, nearly anytime `componentWillReceiveProps` fires, it will initialize a new builder. 

This PR should resolve the dragula error. However, there is remaining unexpected behavior related to handling updated props that this PR does _not_ fix. For instance, if you add a form component and toggle to wizard mode, then you will not be able to remove the component that you added in form mode (although, you will be able to remove any components added in wizard mode).

```js
import React from 'react'
const { FormBuilder } = require('react-formio')

class App extends React.Component {
  constructor (props) {
    super(props)
    this.state = { display: 'form' }
    this.toggle = this.toggle.bind(this)
  }
  toggle () {
    const display = this.state.display === 'form' ? 'wizard' : 'form'
    this.setState({ display })
  }
  render () {
    return (
      <div>
        <button onClick={this.toggle}>Toggle Display</button>
        <FormBuilder form={this.state} />
      </div>
    )
  }
}
```