### PR TITLE
Upgrading react-formio@1.x to support React v16

### DIFF
--- a/lib/components/FormComponents/address.js
+++ b/lib/components/FormComponents/address.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _react = require('react');
+var _createReactClass = require('create-react-class');
 
-var _react2 = _interopRequireDefault(_react);
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _valueMixin = require('./mixins/valueMixin');
 
@@ -22,7 +22,7 @@ var _debounce2 = _interopRequireDefault(_debounce);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Address',
   mixins: [_valueMixin2.default, _selectMixin2.default, _componentMixin2.default],
   getTextField: function getTextField() {

--- a/lib/components/FormComponents/button.js
+++ b/lib/components/FormComponents/button.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _componentMixin = require('./mixins/componentMixin');
 
 var _componentMixin2 = _interopRequireDefault(_componentMixin);
@@ -11,7 +15,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // TODO: Support other button actions like reset.
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Button',
   mixins: [_componentMixin2.default],
   getButtonType: function getButtonType() {

--- a/lib/components/FormComponents/checkbox.js
+++ b/lib/components/FormComponents/checkbox.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -14,7 +18,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Checkbox',
   mixins: [_valueMixin2.default, _componentMixin2.default],
   onChangeCheckbox: function onChangeCheckbox(event) {

--- a/lib/components/FormComponents/columns.js
+++ b/lib/components/FormComponents/columns.js
@@ -2,6 +2,10 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _class, _temp;
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -10,22 +14,40 @@ var _components = require('../../components');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
-  displayName: 'Column',
-  render: function render() {
-    return _react2.default.createElement(
-      'div',
-      { className: 'row' },
-      this.props.component.columns.map(function (column, index) {
-        var classes = 'col-sm-' + (column.width || 6) + (column.offset ? ' col-sm-offset-' + column.offset : '') + (column.push ? ' col-sm-push-' + column.push : '') + (column.pull ? ' col-sm-pull-' + column.pull : '');
-        return _react2.default.createElement(
-          'div',
-          { key: index, className: classes },
-          _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
-            components: column.components
-          }))
-        );
-      }.bind(this))
-    );
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+module.exports = (_temp = _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
+
+  function _class() {
+    _classCallCheck(this, _class);
+
+    return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
   }
-});
+
+  _createClass(_class, [{
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'div',
+        { className: 'row' },
+        this.props.component.columns.map(function (column, index) {
+          var classes = 'col-sm-' + (column.width || 6) + (column.offset ? ' col-sm-offset-' + column.offset : '') + (column.push ? ' col-sm-push-' + column.push : '') + (column.pull ? ' col-sm-pull-' + column.pull : '');
+          return _react2.default.createElement(
+            'div',
+            { key: index, className: classes },
+            _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
+              components: column.components
+            }))
+          );
+        }.bind(this))
+      );
+    }
+  }]);
+
+  return _class;
+}(_react2.default.Component), _class.displayName = 'Column', _temp);

--- a/lib/components/FormComponents/container.js
+++ b/lib/components/FormComponents/container.js
@@ -6,6 +6,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _clone = require('lodash/clone');
 
 var _clone2 = _interopRequireDefault(_clone);
@@ -22,7 +26,7 @@ var _components = require('../../components');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Container',
   mixins: [_valueMixin2.default, _componentMixin2.default],
   getInitialValue: function getInitialValue() {

--- a/lib/components/FormComponents/content.js
+++ b/lib/components/FormComponents/content.js
@@ -4,13 +4,17 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _componentMixin = require('./mixins/componentMixin');
 
 var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Content',
   mixins: [_componentMixin2.default],
   render: function render() {

--- a/lib/components/FormComponents/currency.js
+++ b/lib/components/FormComponents/currency.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _react = require('react');
+var _createReactClass = require('create-react-class');
 
-var _react2 = _interopRequireDefault(_react);
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _valueMixin = require('./mixins/valueMixin');
 
@@ -30,7 +30,7 @@ var _repeat3 = _interopRequireDefault(_repeat2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Currency',
   mixins: [_inputMixin2.default, _valueMixin2.default, _multiMixin2.default, _componentMixin2.default],
   onChangeCustom: function onChangeCustom(value) {

--- a/lib/components/FormComponents/custom.js
+++ b/lib/components/FormComponents/custom.js
@@ -4,13 +4,17 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _componentMixin = require('./mixins/componentMixin');
 
 var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Custom',
   mixins: [_componentMixin2.default],
   render: function render() {

--- a/lib/components/FormComponents/datagrid.js
+++ b/lib/components/FormComponents/datagrid.js
@@ -6,6 +6,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _clone = require('lodash/clone');
 
 var _clone2 = _interopRequireDefault(_clone);
@@ -138,7 +142,7 @@ var DataGridRow = function (_React$Component) {
   return DataGridRow;
 }(_react2.default.Component);
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Datagrid',
   mixins: [_valueMixin2.default],
   getInitialValue: function getInitialValue() {

--- a/lib/components/FormComponents/datetime.js
+++ b/lib/components/FormComponents/datetime.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -26,7 +30,7 @@ var _get3 = _interopRequireDefault(_get2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Datetime',
   mixins: [_valueMixin2.default, _multiMixin2.default, _componentMixin2.default],
   getInitialValue: function getInitialValue() {

--- a/lib/components/FormComponents/day.js
+++ b/lib/components/FormComponents/day.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -22,7 +26,7 @@ var _reactTextMask2 = _interopRequireDefault(_reactTextMask);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Textfield',
   noErrorClass: true,
   mixins: [_valueMixin2.default, _multiMixin2.default, _componentMixin2.default],

--- a/lib/components/FormComponents/editgrid.js
+++ b/lib/components/FormComponents/editgrid.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _clone = require('lodash/clone');
 
 var _clone2 = _interopRequireDefault(_clone);
@@ -312,7 +316,7 @@ var RowEdit = function (_React$Component) {
   return RowEdit;
 }(_react2.default.Component);
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
   displayName: 'EditGrid',
   noErrorClass: true,
   mixins: [_valueMixin2.default],

--- a/lib/components/FormComponents/email.js
+++ b/lib/components/FormComponents/email.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _react = require('react');
+var _createReactClass = require('create-react-class');
 
-var _react2 = _interopRequireDefault(_react);
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _valueMixin = require('./mixins/valueMixin');
 
@@ -22,7 +22,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Email',
   mixins: [_valueMixin2.default, _multiMixin2.default, _inputMixin2.default, _componentMixin2.default]
 });

--- a/lib/components/FormComponents/fieldset.js
+++ b/lib/components/FormComponents/fieldset.js
@@ -2,6 +2,10 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _class, _temp;
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -10,22 +14,40 @@ var _components = require('../../components');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
-  displayName: 'Fieldset',
-  render: function render() {
-    var legend = this.props.component.legend ? _react2.default.createElement(
-      'legend',
-      null,
-      this.props.component.legend
-    ) : '';
-    var className = this.props.component.customClass ? this.props.component.customClass : '';
-    return _react2.default.createElement(
-      'fieldset',
-      { className: className },
-      legend,
-      _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
-        components: this.props.component.components
-      }))
-    );
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+module.exports = (_temp = _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
+
+  function _class() {
+    _classCallCheck(this, _class);
+
+    return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
   }
-});
+
+  _createClass(_class, [{
+    key: 'render',
+    value: function render() {
+      var legend = this.props.component.legend ? _react2.default.createElement(
+        'legend',
+        null,
+        this.props.component.legend
+      ) : '';
+      var className = this.props.component.customClass ? this.props.component.customClass : '';
+      return _react2.default.createElement(
+        'fieldset',
+        { className: className },
+        legend,
+        _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
+          components: this.props.component.components
+        }))
+      );
+    }
+  }]);
+
+  return _class;
+}(_react2.default.Component), _class.displayName = 'Fieldset', _temp);

--- a/lib/components/FormComponents/file.js
+++ b/lib/components/FormComponents/file.js
@@ -1,8 +1,14 @@
 'use strict';
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _reactDropzone = require('react-dropzone');
 
@@ -20,161 +26,243 @@ var _util = require('../../util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var FormioFileList = _react2.default.createClass({
-  displayName: 'FormioFileList',
-  fileRow: function fileRow(file, index) {
-    var _this = this;
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-    if (!file) {
-      return null;
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var FormioFileList = function (_React$Component) {
+  _inherits(FormioFileList, _React$Component);
+
+  function FormioFileList() {
+    var _ref;
+
+    var _temp, _this, _ret;
+
+    _classCallCheck(this, FormioFileList);
+
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
     }
-    return _react2.default.createElement(
-      'tr',
-      { key: index },
-      function () {
-        if (!_this.props.readOnly) {
-          return _react2.default.createElement(
-            'td',
-            { className: 'formio-dropzone-table' },
-            _react2.default.createElement(
-              'a',
-              { onClick: _this.props.removeFile.bind(null, index), className: 'btn btn-sm btn-default' },
-              _react2.default.createElement('span', { className: 'glyphicon glyphicon-remove' })
-            )
-          );
-        }
-      }(),
-      _react2.default.createElement(
-        'td',
-        null,
-        _react2.default.createElement(FormioFile, { file: file, formio: this.props.formio })
-      ),
-      _react2.default.createElement(
-        'td',
-        null,
-        (0, _util.fileSize)(file.size)
-      )
-    );
-  },
-  render: function render() {
-    var _this2 = this;
 
-    return _react2.default.createElement(
-      'table',
-      { className: 'table table-striped table-bordered' },
-      _react2.default.createElement(
-        'thead',
-        null,
-        _react2.default.createElement(
-          'tr',
-          null,
-          function () {
-            if (!_this2.props.readOnly) {
-              return _react2.default.createElement('th', { className: 'formio-dropzone-table' });
-            }
-          }(),
-          _react2.default.createElement(
-            'th',
-            null,
-            'File Name'
-          ),
-          _react2.default.createElement(
-            'th',
-            null,
-            'Size'
-          )
-        )
-      ),
-      _react2.default.createElement(
-        'tbody',
-        null,
-        this.props.files ? this.props.files.map(this.fileRow) : null
-      )
-    );
-  }
-});
-
-var FormioImageList = _react2.default.createClass({
-  displayName: 'FormioImageList',
-  render: function render() {
-    var _this3 = this;
-
-    return _react2.default.createElement(
-      'div',
-      null,
-      this.props.files ? this.props.files.map(function (file, index) {
-        return _react2.default.createElement(
-          'span',
-          { key: index },
-          _react2.default.createElement(FormioImage, { file: file, formio: _this3.props.formio, width: _this3.props.width }),
-          function () {
-            if (!_this3.props.readOnly) {
-              return _react2.default.createElement(
-                'span',
-                { style: { width: '1%', 'white-space': 'nowrap' } },
-                _react2.default.createElement(
-                  'a',
-                  { onClick: _this3.props.removeFile.bind(null, index), className: 'btn btn-sm btn-default' },
-                  _react2.default.createElement('span', { className: 'glyphicon glyphicon-remove' })
-                )
-              );
-            }
-          }()
-        );
-      }) : null
-    );
-  }
-});
-
-var FormioFile = _react2.default.createClass({
-  displayName: 'FormioFile',
-  getFile: function getFile(event) {
-    event.preventDefault();
-    this.props.formio.downloadFile(this.props.file).then(function (file) {
-      if (file) {
-        window.open(file.url, '_blank');
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = FormioFileList.__proto__ || Object.getPrototypeOf(FormioFileList)).call.apply(_ref, [this].concat(args))), _this), _this.fileRow = function (file, index) {
+      if (!file) {
+        return null;
       }
-    }).catch(function (response) {
-      // Is alert the best way to do this?
-      // User is expecting an immediate notification due to attempting to download a file.
-      alert(response);
-    });
-  },
-  render: function render() {
-    var _this4 = this;
-
-    return _react2.default.createElement(
-      'a',
-      { href: this.props.file.url, onClick: function onClick(event) {
-          _this4.getFile(event);
-        }, target: '_blank' },
-      this.props.file.name
-    );
+      return _react2.default.createElement(
+        'tr',
+        { key: index },
+        function () {
+          if (!_this.props.readOnly) {
+            return _react2.default.createElement(
+              'td',
+              { className: 'formio-dropzone-table' },
+              _react2.default.createElement(
+                'a',
+                { onClick: _this.props.removeFile.bind(null, index), className: 'btn btn-sm btn-default' },
+                _react2.default.createElement('span', { className: 'glyphicon glyphicon-remove' })
+              )
+            );
+          }
+        }(),
+        _react2.default.createElement(
+          'td',
+          null,
+          _react2.default.createElement(FormioFile, { file: file, formio: _this.props.formio })
+        ),
+        _react2.default.createElement(
+          'td',
+          null,
+          (0, _util.fileSize)(file.size)
+        )
+      );
+    }, _temp), _possibleConstructorReturn(_this, _ret);
   }
-});
 
-var FormioImage = _react2.default.createClass({
-  displayName: 'FormioImage',
-  getInitialState: function getInitialState() {
-    return {
-      imageSrc: ''
-    };
-  },
-  componentWillMount: function componentWillMount() {
-    var _this5 = this;
+  _createClass(FormioFileList, [{
+    key: 'render',
+    value: function render() {
+      var _this2 = this;
 
-    this.props.formio.downloadFile(this.props.file).then(function (result) {
-      _this5.setState({
-        imageSrc: result.url
+      return _react2.default.createElement(
+        'table',
+        { className: 'table table-striped table-bordered' },
+        _react2.default.createElement(
+          'thead',
+          null,
+          _react2.default.createElement(
+            'tr',
+            null,
+            function () {
+              if (!_this2.props.readOnly) {
+                return _react2.default.createElement('th', { className: 'formio-dropzone-table' });
+              }
+            }(),
+            _react2.default.createElement(
+              'th',
+              null,
+              'File Name'
+            ),
+            _react2.default.createElement(
+              'th',
+              null,
+              'Size'
+            )
+          )
+        ),
+        _react2.default.createElement(
+          'tbody',
+          null,
+          this.props.files ? this.props.files.map(this.fileRow) : null
+        )
+      );
+    }
+  }]);
+
+  return FormioFileList;
+}(_react2.default.Component);
+
+FormioFileList.displayName = 'FormioFileList';
+
+var FormioImageList = function (_React$Component2) {
+  _inherits(FormioImageList, _React$Component2);
+
+  function FormioImageList() {
+    _classCallCheck(this, FormioImageList);
+
+    return _possibleConstructorReturn(this, (FormioImageList.__proto__ || Object.getPrototypeOf(FormioImageList)).apply(this, arguments));
+  }
+
+  _createClass(FormioImageList, [{
+    key: 'render',
+    value: function render() {
+      var _this4 = this;
+
+      return _react2.default.createElement(
+        'div',
+        null,
+        this.props.files ? this.props.files.map(function (file, index) {
+          return _react2.default.createElement(
+            'span',
+            { key: index },
+            _react2.default.createElement(FormioImage, { file: file, formio: _this4.props.formio, width: _this4.props.width }),
+            function () {
+              if (!_this4.props.readOnly) {
+                return _react2.default.createElement(
+                  'span',
+                  { style: { width: '1%', 'white-space': 'nowrap' } },
+                  _react2.default.createElement(
+                    'a',
+                    { onClick: _this4.props.removeFile.bind(null, index), className: 'btn btn-sm btn-default' },
+                    _react2.default.createElement('span', { className: 'glyphicon glyphicon-remove' })
+                  )
+                );
+              }
+            }()
+          );
+        }) : null
+      );
+    }
+  }]);
+
+  return FormioImageList;
+}(_react2.default.Component);
+
+FormioImageList.displayName = 'FormioImageList';
+
+var FormioFile = function (_React$Component3) {
+  _inherits(FormioFile, _React$Component3);
+
+  function FormioFile() {
+    var _ref2;
+
+    var _temp2, _this5, _ret2;
+
+    _classCallCheck(this, FormioFile);
+
+    for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+      args[_key2] = arguments[_key2];
+    }
+
+    return _ret2 = (_temp2 = (_this5 = _possibleConstructorReturn(this, (_ref2 = FormioFile.__proto__ || Object.getPrototypeOf(FormioFile)).call.apply(_ref2, [this].concat(args))), _this5), _this5.getFile = function (event) {
+      event.preventDefault();
+      _this5.props.formio.downloadFile(_this5.props.file).then(function (file) {
+        if (file) {
+          window.open(file.url, '_blank');
+        }
+      }).catch(function (response) {
+        // Is alert the best way to do this?
+        // User is expecting an immediate notification due to attempting to download a file.
+        alert(response);
       });
-    });
-  },
-  render: function render() {
-    return _react2.default.createElement('img', { src: this.state.imageSrc, alt: this.props.file.name, style: { width: this.props.width } });
+    }, _temp2), _possibleConstructorReturn(_this5, _ret2);
   }
-});
 
-module.exports = _react2.default.createClass({
+  _createClass(FormioFile, [{
+    key: 'render',
+    value: function render() {
+      var _this6 = this;
+
+      return _react2.default.createElement(
+        'a',
+        { href: this.props.file.url, onClick: function onClick(event) {
+            _this6.getFile(event);
+          }, target: '_blank' },
+        this.props.file.name
+      );
+    }
+  }]);
+
+  return FormioFile;
+}(_react2.default.Component);
+
+FormioFile.displayName = 'FormioFile';
+
+var FormioImage = function (_React$Component4) {
+  _inherits(FormioImage, _React$Component4);
+
+  function FormioImage() {
+    var _ref3;
+
+    var _temp3, _this7, _ret3;
+
+    _classCallCheck(this, FormioImage);
+
+    for (var _len3 = arguments.length, args = Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+      args[_key3] = arguments[_key3];
+    }
+
+    return _ret3 = (_temp3 = (_this7 = _possibleConstructorReturn(this, (_ref3 = FormioImage.__proto__ || Object.getPrototypeOf(FormioImage)).call.apply(_ref3, [this].concat(args))), _this7), _this7.state = {
+      imageSrc: ''
+    }, _temp3), _possibleConstructorReturn(_this7, _ret3);
+  }
+
+  _createClass(FormioImage, [{
+    key: 'componentWillMount',
+    value: function componentWillMount() {
+      var _this8 = this;
+
+      this.props.formio.downloadFile(this.props.file).then(function (result) {
+        _this8.setState({
+          imageSrc: result.url
+        });
+      });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement('img', { src: this.state.imageSrc, alt: this.props.file.name, style: { width: this.props.width } });
+    }
+  }]);
+
+  return FormioImage;
+}(_react2.default.Component);
+
+FormioImage.displayName = 'FormioImage';
+
+
+module.exports = (0, _createReactClass2.default)({
   displayName: 'File',
   mixins: [_valueMixin2.default, _componentMixin2.default],
   getInitialValue: function getInitialValue() {
@@ -214,13 +302,13 @@ module.exports = _react2.default.createClass({
     }
   },
   upload: function upload(files) {
-    var _this6 = this;
+    var _this9 = this;
 
     if (this.props.component.storage && files && files.length) {
       files.forEach(function (file) {
         // Get a unique name for this file to keep file collisions from occurring.
-        var fileName = _this6.uniqueName(file.name);
-        _this6.setState(function (previousState) {
+        var fileName = _this9.uniqueName(file.name);
+        _this9.setState(function (previousState) {
           previousState.fileUploads[fileName] = {
             name: fileName,
             size: file.size,
@@ -229,22 +317,22 @@ module.exports = _react2.default.createClass({
           };
           return previousState;
         });
-        var dir = _this6.props.component.dir || '';
-        _this6.props.formio.uploadFile(_this6.props.component.storage, file, fileName, dir, function (evt) {
-          _this6.setState(function (previousState) {
+        var dir = _this9.props.component.dir || '';
+        _this9.props.formio.uploadFile(_this9.props.component.storage, file, fileName, dir, function (evt) {
+          _this9.setState(function (previousState) {
             previousState.fileUploads[fileName].status = 'progress';
             previousState.fileUploads[fileName].progress = parseInt(100.0 * evt.loaded / evt.total);
             delete previousState.fileUploads[fileName].message;
             return previousState;
           });
         }).then(function (fileInfo) {
-          _this6.setState(function (previousState) {
+          _this9.setState(function (previousState) {
             delete previousState.fileUploads[fileName];
             return previousState;
           });
-          _this6.setValue(fileInfo, _this6.state.value.length);
+          _this9.setValue(fileInfo, _this9.state.value.length);
         }).catch(function (response) {
-          _this6.setState(function (previousState) {
+          _this9.setState(function (previousState) {
             previousState.fileUploads[fileName].status = 'error';
             previousState.fileUploads[fileName].message = response;
             delete previousState.fileUploads[fileName].progress;
@@ -360,7 +448,7 @@ module.exports = _react2.default.createClass({
     }
   },
   getElements: function getElements() {
-    var _this7 = this;
+    var _this10 = this;
 
     var classLabel = 'control-label' + (this.props.component.validate && this.props.component.validate.required ? ' field-required' : '');
     var inputLabel = this.props.component.label && !this.props.component.hideLabel ? _react2.default.createElement(
@@ -378,14 +466,14 @@ module.exports = _react2.default.createClass({
       requiredInline,
       this.fileList(),
       function () {
-        if (!_this7.props.readOnly) {
+        if (!_this10.props.readOnly) {
           return _react2.default.createElement(
             'div',
             null,
-            _this7.fileSelector(),
-            _this7.props.component.storage ? null : _this7.noStorageError(),
-            Object.keys(_this7.state.fileUploads).map(function (key) {
-              return _this7.fileUpload(_this7.state.fileUploads[key], key);
+            _this10.fileSelector(),
+            _this10.props.component.storage ? null : _this10.noStorageError(),
+            Object.keys(_this10.state.fileUploads).map(function (key) {
+              return _this10.fileUpload(_this10.state.fileUploads[key], key);
             })
           );
         }

--- a/lib/components/FormComponents/hidden.js
+++ b/lib/components/FormComponents/hidden.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -14,7 +18,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   mixins: [_valueMixin2.default, _componentMixin2.default],
   displayName: 'Hidden',
   getElements: function getElements() {

--- a/lib/components/FormComponents/htmlelement.js
+++ b/lib/components/FormComponents/htmlelement.js
@@ -6,13 +6,17 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _componentMixin = require('./mixins/componentMixin');
 
 var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'HtmlElement',
   mixins: [_componentMixin2.default],
   render: function render(value, index) {

--- a/lib/components/FormComponents/mixins/selectMixin.js
+++ b/lib/components/FormComponents/mixins/selectMixin.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
@@ -36,13 +36,13 @@ var _isEqual2 = _interopRequireDefault(_isEqual);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 module.exports = {
   data: {},
@@ -141,30 +141,8 @@ module.exports = {
       }
     }
 
-    return _react2.default.createClass({
-      render: function render() {
-        var item = this.props.item;
-
-        if (component.dataSrc === 'values') {
-          // Search for the full item from values.
-          item = _.find(component.data.values, { value: item }) || item;
-        } else if (component.dataSrc === 'json' && component.valueProperty && item && (typeof item === 'undefined' ? 'undefined' : _typeof(item)) !== 'object') {
-          item = _.find(items, _defineProperty({}, component.valueProperty, item)) || item;
-        }
-
-        if (item && (typeof item === 'undefined' ? 'undefined' : _typeof(item)) === 'object') {
-          // Render the markup raw under this react element
-          return _react2.default.createElement('span', (0, _util.raw)((0, _util.interpolate)(component.template, { item: item })));
-        }
-
-        return _react2.default.createElement('span', {}, item);
-      }
-    });
-  },
-  listComponent: function listComponent() {
-    var root = this;
-    return function (_List) {
-      _inherits(_class, _List);
+    return function (_React$Component) {
+      _inherits(_class, _React$Component);
 
       function _class() {
         _classCallCheck(this, _class);
@@ -173,6 +151,41 @@ module.exports = {
       }
 
       _createClass(_class, [{
+        key: 'render',
+        value: function render() {
+          var item = this.props.item;
+
+          if (component.dataSrc === 'values') {
+            // Search for the full item from values.
+            item = _.find(component.data.values, { value: item }) || item;
+          } else if (component.dataSrc === 'json' && component.valueProperty && item && (typeof item === 'undefined' ? 'undefined' : _typeof(item)) !== 'object') {
+            item = _.find(items, _defineProperty({}, component.valueProperty, item)) || item;
+          }
+
+          if (item && (typeof item === 'undefined' ? 'undefined' : _typeof(item)) === 'object') {
+            // Render the markup raw under this react element
+            return _react2.default.createElement('span', (0, _util.raw)((0, _util.interpolate)(component.template, { item: item })));
+          }
+
+          return _react2.default.createElement('span', {}, item);
+        }
+      }]);
+
+      return _class;
+    }(_react2.default.Component);
+  },
+  listComponent: function listComponent() {
+    var root = this;
+    return function (_List) {
+      _inherits(_class2, _List);
+
+      function _class2() {
+        _classCallCheck(this, _class2);
+
+        return _possibleConstructorReturn(this, (_class2.__proto__ || Object.getPrototypeOf(_class2)).apply(this, arguments));
+      }
+
+      _createClass(_class2, [{
         key: 'render',
         value: function render() {
           var loadMore;
@@ -186,25 +199,25 @@ module.exports = {
           return _react2.default.createElement(
             'div',
             { className: 'wrapper' },
-            _get(_class.prototype.__proto__ || Object.getPrototypeOf(_class.prototype), 'render', this).call(this),
+            _get(_class2.prototype.__proto__ || Object.getPrototypeOf(_class2.prototype), 'render', this).call(this),
             loadMore
           );
         }
       }]);
 
-      return _class;
+      return _class2;
     }(_List3.default);
   },
   getElements: function getElements() {
-    var _this2 = this;
+    var _this3 = this;
 
     var Element;
     var properties = {
       data: this.state.selectItems.filter(function (value) {
-        if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && _this2.valueField()) {
-          value = (0, _get3.default)(value, _this2.valueField());
+        if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && _this3.valueField()) {
+          value = (0, _get3.default)(value, _this3.valueField());
         }
-        return _this2.state.value !== value;
+        return _this3.state.value !== value;
       }),
       placeholder: this.props.component.placeholder,
       textField: this.textField(),

--- a/lib/components/FormComponents/number.js
+++ b/lib/components/FormComponents/number.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _react = require('react');
+var _createReactClass = require('create-react-class');
 
-var _react2 = _interopRequireDefault(_react);
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _valueMixin = require('./mixins/valueMixin');
 
@@ -30,7 +30,7 @@ var _repeat3 = _interopRequireDefault(_repeat2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Number',
   mixins: [_valueMixin2.default, _multiMixin2.default, _componentMixin2.default, _inputMixin2.default],
   onChangeCustom: function onChangeCustom(value) {

--- a/lib/components/FormComponents/panel.js
+++ b/lib/components/FormComponents/panel.js
@@ -2,6 +2,10 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _class, _temp;
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -10,30 +14,48 @@ var _components = require('../../components');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
-  displayName: 'Panel',
-  render: function render() {
-    var title = this.props.component.title ? _react2.default.createElement(
-      'div',
-      { className: 'panel-heading' },
-      _react2.default.createElement(
-        'h3',
-        { className: 'panel-title' },
-        this.props.component.title
-      )
-    ) : '';
-    var className = 'panel panel-' + this.props.component.theme + ' ' + (this.props.component.customClass ? this.props.component.customClass : '');
-    return _react2.default.createElement(
-      'div',
-      { className: className },
-      title,
-      _react2.default.createElement(
-        'div',
-        { className: 'panel-body' },
-        _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
-          components: this.props.component.components
-        }))
-      )
-    );
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+module.exports = (_temp = _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
+
+  function _class() {
+    _classCallCheck(this, _class);
+
+    return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
   }
-});
+
+  _createClass(_class, [{
+    key: 'render',
+    value: function render() {
+      var title = this.props.component.title ? _react2.default.createElement(
+        'div',
+        { className: 'panel-heading' },
+        _react2.default.createElement(
+          'h3',
+          { className: 'panel-title' },
+          this.props.component.title
+        )
+      ) : '';
+      var className = 'panel panel-' + this.props.component.theme + ' ' + (this.props.component.customClass ? this.props.component.customClass : '');
+      return _react2.default.createElement(
+        'div',
+        { className: className },
+        title,
+        _react2.default.createElement(
+          'div',
+          { className: 'panel-body' },
+          _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
+            components: this.props.component.components
+          }))
+        )
+      );
+    }
+  }]);
+
+  return _class;
+}(_react2.default.Component), _class.displayName = 'Panel', _temp);

--- a/lib/components/FormComponents/password.js
+++ b/lib/components/FormComponents/password.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _react = require('react');
+var _createReactClass = require('create-react-class');
 
-var _react2 = _interopRequireDefault(_react);
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _valueMixin = require('./mixins/valueMixin');
 
@@ -22,7 +22,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Password',
   mixins: [_valueMixin2.default, _multiMixin2.default, _inputMixin2.default, _componentMixin2.default]
 });

--- a/lib/components/FormComponents/phoneNumber.js
+++ b/lib/components/FormComponents/phoneNumber.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _react = require('react');
+var _createReactClass = require('create-react-class');
 
-var _react2 = _interopRequireDefault(_react);
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _valueMixin = require('./mixins/valueMixin');
 
@@ -22,7 +22,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'PhoneNumber',
   mixins: [_valueMixin2.default, _multiMixin2.default, _inputMixin2.default, _componentMixin2.default]
 });

--- a/lib/components/FormComponents/radio.js
+++ b/lib/components/FormComponents/radio.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -18,7 +22,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Radio',
   mixins: [_valueMixin2.default, _multiMixin2.default, _componentMixin2.default],
   onChangeRadio: function onChangeRadio(event) {

--- a/lib/components/FormComponents/resource.js
+++ b/lib/components/FormComponents/resource.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -24,7 +28,7 @@ var _formiojs2 = _interopRequireDefault(_formiojs);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Resource',
   mixins: [_valueMixin2.default, _selectMixin2.default, _componentMixin2.default],
   componentWillMount: function componentWillMount() {

--- a/lib/components/FormComponents/select.js
+++ b/lib/components/FormComponents/select.js
@@ -6,6 +6,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -34,7 +38,7 @@ var _debounce2 = _interopRequireDefault(_debounce);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   options: {},
   lastInput: '',
   displayName: 'Select',

--- a/lib/components/FormComponents/selectboxes.js
+++ b/lib/components/FormComponents/selectboxes.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -18,7 +22,7 @@ var _clone2 = _interopRequireDefault(_clone);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'SelectBox',
   mixins: [_valueMixin2.default, _componentMixin2.default],
   getInitialValue: function getInitialValue() {

--- a/lib/components/FormComponents/signature.js
+++ b/lib/components/FormComponents/signature.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -22,7 +26,7 @@ var _lodash2 = _interopRequireDefault(_lodash);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Signature',
   mixins: [_valueMixin2.default, _componentMixin2.default],
   onEnd: function onEnd() {

--- a/lib/components/FormComponents/survey.js
+++ b/lib/components/FormComponents/survey.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -14,7 +18,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Survey',
   mixins: [_valueMixin2.default, _componentMixin2.default],
   getInitialValue: function getInitialValue() {

--- a/lib/components/FormComponents/table.js
+++ b/lib/components/FormComponents/table.js
@@ -2,6 +2,10 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _class, _temp;
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -10,62 +14,80 @@ var _components = require('../../components');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
-  displayName: 'Panel',
-  render: function render() {
-    var title = this.props.component.title ? _react2.default.createElement(
-      'div',
-      { className: 'panel-heading' },
-      _react2.default.createElement(
-        'h3',
-        { className: 'panel-title' },
-        this.props.component.title
-      )
-    ) : '';
-    var tableClasses = 'table';
-    tableClasses += this.props.component.striped ? ' table-striped' : '';
-    tableClasses += this.props.component.bordered ? ' table-bordered' : '';
-    tableClasses += this.props.component.hover ? ' table-hover' : '';
-    tableClasses += this.props.component.condensed ? ' table-condensed' : '';
-    tableClasses += this.props.component.customClass ? ' ' + this.props.component.customClass : '';
-    return _react2.default.createElement(
-      'div',
-      { className: 'table-responsive' },
-      title,
-      _react2.default.createElement(
-        'table',
-        { className: tableClasses },
-        _react2.default.createElement(
-          'thead',
-          null,
-          this.props.component.header.map(function (header, index) {
-            return _react2.default.createElement(
-              'th',
-              { key: index },
-              header
-            );
-          }.bind(this))
-        ),
-        _react2.default.createElement(
-          'tbody',
-          null,
-          this.props.component.rows.map(function (row, index) {
-            return _react2.default.createElement(
-              'tr',
-              { key: index },
-              row.map(function (column, index) {
-                return _react2.default.createElement(
-                  'td',
-                  { key: index },
-                  _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
-                    components: column.components
-                  }))
-                );
-              }.bind(this))
-            );
-          }.bind(this))
-        )
-      )
-    );
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+module.exports = (_temp = _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
+
+  function _class() {
+    _classCallCheck(this, _class);
+
+    return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
   }
-});
+
+  _createClass(_class, [{
+    key: 'render',
+    value: function render() {
+      var title = this.props.component.title ? _react2.default.createElement(
+        'div',
+        { className: 'panel-heading' },
+        _react2.default.createElement(
+          'h3',
+          { className: 'panel-title' },
+          this.props.component.title
+        )
+      ) : '';
+      var tableClasses = 'table';
+      tableClasses += this.props.component.striped ? ' table-striped' : '';
+      tableClasses += this.props.component.bordered ? ' table-bordered' : '';
+      tableClasses += this.props.component.hover ? ' table-hover' : '';
+      tableClasses += this.props.component.condensed ? ' table-condensed' : '';
+      tableClasses += this.props.component.customClass ? ' ' + this.props.component.customClass : '';
+      return _react2.default.createElement(
+        'div',
+        { className: 'table-responsive' },
+        title,
+        _react2.default.createElement(
+          'table',
+          { className: tableClasses },
+          _react2.default.createElement(
+            'thead',
+            null,
+            this.props.component.header.map(function (header, index) {
+              return _react2.default.createElement(
+                'th',
+                { key: index },
+                header
+              );
+            }.bind(this))
+          ),
+          _react2.default.createElement(
+            'tbody',
+            null,
+            this.props.component.rows.map(function (row, index) {
+              return _react2.default.createElement(
+                'tr',
+                { key: index },
+                row.map(function (column, index) {
+                  return _react2.default.createElement(
+                    'td',
+                    { key: index },
+                    _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
+                      components: column.components
+                    }))
+                  );
+                }.bind(this))
+              );
+            }.bind(this))
+          )
+        )
+      );
+    }
+  }]);
+
+  return _class;
+}(_react2.default.Component), _class.displayName = 'Panel', _temp);

--- a/lib/components/FormComponents/textarea.js
+++ b/lib/components/FormComponents/textarea.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _reactQuill = require('react-quill');
 
 var _reactQuill2 = _interopRequireDefault(_reactQuill);
@@ -22,7 +26,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Textarea',
   mixins: [_valueMixin2.default, _multiMixin2.default, _componentMixin2.default],
   customState: function customState(state) {

--- a/lib/components/FormComponents/textfield.js
+++ b/lib/components/FormComponents/textfield.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _react = require('react');
+var _createReactClass = require('create-react-class');
 
-var _react2 = _interopRequireDefault(_react);
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _valueMixin = require('./mixins/valueMixin');
 
@@ -22,7 +22,7 @@ var _componentMixin2 = _interopRequireDefault(_componentMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Textfield',
   mixins: [_valueMixin2.default, _multiMixin2.default, _inputMixin2.default, _componentMixin2.default]
 });

--- a/lib/components/FormComponents/time.js
+++ b/lib/components/FormComponents/time.js
@@ -4,6 +4,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _valueMixin = require('./mixins/valueMixin');
 
 var _valueMixin2 = _interopRequireDefault(_valueMixin);
@@ -22,7 +26,7 @@ var _moment2 = _interopRequireDefault(_moment);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
+module.exports = (0, _createReactClass2.default)({
   displayName: 'Time',
   mixins: [_valueMixin2.default, _multiMixin2.default, _componentMixin2.default],
   customState: function customState(state) {

--- a/lib/components/FormComponents/well.js
+++ b/lib/components/FormComponents/well.js
@@ -2,6 +2,10 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _class, _temp;
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -10,15 +14,33 @@ var _components = require('../../components');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = _react2.default.createClass({
-  displayName: 'Well',
-  render: function render() {
-    return _react2.default.createElement(
-      'div',
-      { className: 'well' },
-      _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
-        components: this.props.component.components
-      }))
-    );
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+module.exports = (_temp = _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
+
+  function _class() {
+    _classCallCheck(this, _class);
+
+    return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
   }
-});
+
+  _createClass(_class, [{
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'div',
+        { className: 'well' },
+        _react2.default.createElement(_components.FormioComponentsList, _extends({}, this.props, {
+          components: this.props.component.components
+        }))
+      );
+    }
+  }]);
+
+  return _class;
+}(_react2.default.Component), _class.displayName = 'Well', _temp);

--- a/lib/components/Formio.js
+++ b/lib/components/Formio.js
@@ -9,6 +9,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _formiojs = require('formiojs');
 
 var _formiojs2 = _interopRequireDefault(_formiojs);
@@ -32,7 +36,7 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 // TODO: We should have a better way of initializing form components.
 
 
-var Formio = exports.Formio = _react2.default.createClass({
+var Formio = exports.Formio = (0, _createReactClass2.default)({
   displayName: 'Formio',
   getInitialState: function getInitialState() {
     this.unmounting = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1717,10 +1717,9 @@
       "dev": true
     },
     "create-react-class": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
-      "dev": true,
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
         "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React rendering library for form.io embedded forms.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha --timeout 30000 --reporter spec test/.setup.js **/*.spec.js",
+    "test": "mocha --timeout 30000 --reporter spec test/.setup.js src/**/*.spec.js test/**/*.spec.js",
     "build": "babel ./src --ignore=*.spec.js --out-dir ./lib --presets es2015,react,stage-2",
     "lint": "eslint src",
     "watch": "babel ./src --watch --ignore=*.spec.js --out-dir ./lib --presets es2015,react,stage-2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.22.0",
+    "create-react-class": "^15.6.3",
     "formio-utils": "^0.3.0",
     "formiojs": "^2.32.3",
     "lodash": "^4.15.0",

--- a/src/components/FormComponents/address.jsx
+++ b/src/components/FormComponents/address.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import selectMixin from './mixins/selectMixin';
 import componentMixin from './mixins/componentMixin';
 import debounce from 'lodash/debounce';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Address',
   mixins: [valueMixin, selectMixin, componentMixin],
   getTextField: function() {

--- a/src/components/FormComponents/button.jsx
+++ b/src/components/FormComponents/button.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import componentMixin from './mixins/componentMixin';
 
 // TODO: Support other button actions like reset.
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Button',
   mixins: [componentMixin],
   getButtonType: function() {

--- a/src/components/FormComponents/checkbox.jsx
+++ b/src/components/FormComponents/checkbox.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Checkbox',
   mixins: [valueMixin, componentMixin],
   onChangeCheckbox: function(event) {

--- a/src/components/FormComponents/columns.jsx
+++ b/src/components/FormComponents/columns.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormioComponentsList } from '../../components';
 
-module.exports = React.createClass({
-  displayName: 'Column',
-  render: function() {
+module.exports = class extends React.Component {
+  static displayName = 'Column';
+
+  render() {
     return (
       <div className='row'>
         {this.props.component.columns.map(function(column, index) {
@@ -23,4 +24,4 @@ module.exports = React.createClass({
       </div>
     );
   }
-});
+};

--- a/src/components/FormComponents/container.jsx
+++ b/src/components/FormComponents/container.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import clone from 'lodash/clone';
 import valueMixin from './mixins/valueMixin';
 import componentMixin from './mixins/componentMixin';
 import { FormioComponentsList } from '../../components';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Container',
   mixins: [valueMixin, componentMixin],
   getInitialValue: function() {

--- a/src/components/FormComponents/content.jsx
+++ b/src/components/FormComponents/content.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Content',
   mixins: [componentMixin],
   render: function() {

--- a/src/components/FormComponents/currency.jsx
+++ b/src/components/FormComponents/currency.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import inputMixin from './mixins/inputMixin';
@@ -6,7 +6,7 @@ import componentMixin from './mixins/componentMixin';
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import _repeat from 'lodash/repeat';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Currency',
   mixins: [inputMixin, valueMixin, multiMixin, componentMixin],
   onChangeCustom: function(value) {

--- a/src/components/FormComponents/custom.jsx
+++ b/src/components/FormComponents/custom.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Custom',
   mixins: [componentMixin],
   render: function() {

--- a/src/components/FormComponents/datagrid.jsx
+++ b/src/components/FormComponents/datagrid.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import clone from 'lodash/clone';
 import isEqual from 'lodash/isEqual';
 import valueMixin from './mixins/valueMixin';
@@ -97,7 +98,7 @@ class DataGridRow extends React.Component {
   }
 }
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Datagrid',
   mixins: [valueMixin],
   getInitialValue: function() {

--- a/src/components/FormComponents/datetime.jsx
+++ b/src/components/FormComponents/datetime.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import componentMixin from './mixins/componentMixin';
 import DateTimePicker from 'react-flatpickr';
 import _get from 'lodash/get';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Datetime',
   mixins: [valueMixin, multiMixin, componentMixin],
   getInitialValue: function() {

--- a/src/components/FormComponents/day.jsx
+++ b/src/components/FormComponents/day.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import componentMixin from './mixins/componentMixin';
 import Input from 'react-text-mask';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Textfield',
   noErrorClass: true,
   mixins: [valueMixin, multiMixin, componentMixin],

--- a/src/components/FormComponents/editgrid.js
+++ b/src/components/FormComponents/editgrid.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import createReactClass from 'create-react-class';
 import clone from 'lodash/clone';
 import isEqual from 'lodash/isEqual';
 import valueMixin from './mixins/valueMixin';
@@ -228,7 +229,7 @@ class RowEdit extends React.Component {
   };
 }
 
-export default React.createClass({
+export default createReactClass({
   displayName: 'EditGrid',
   noErrorClass: true,
   mixins: [valueMixin],

--- a/src/components/FormComponents/email.jsx
+++ b/src/components/FormComponents/email.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import inputMixin from './mixins/inputMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Email',
   mixins: [valueMixin, multiMixin, inputMixin, componentMixin]
 });

--- a/src/components/FormComponents/fieldset.jsx
+++ b/src/components/FormComponents/fieldset.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormioComponentsList } from '../../components';
 
-module.exports = React.createClass({
-  displayName: 'Fieldset',
-  render: function() {
+module.exports = class extends React.Component {
+  static displayName = 'Fieldset';
+
+  render() {
     var legend = (this.props.component.legend ? <legend>{this.props.component.legend}</legend> : '');
     var className = (this.props.component.customClass) ? this.props.component.customClass : '';
     return (
@@ -16,4 +17,4 @@ module.exports = React.createClass({
       </fieldset>
     );
   }
-});
+};

--- a/src/components/FormComponents/file.jsx
+++ b/src/components/FormComponents/file.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Dropzone from 'react-dropzone';
 import valueMixin from './mixins/valueMixin';
 import componentMixin from './mixins/componentMixin';
 import { fileSize } from '../../util';
 
-const FormioFileList = React.createClass({
-  displayName: 'FormioFileList',
-  fileRow: function (file, index) {
+class FormioFileList extends React.Component {
+  static displayName = 'FormioFileList';
+
+  fileRow = (file, index) => {
     if (!file) {
       return null;
     }
@@ -27,8 +29,9 @@ const FormioFileList = React.createClass({
         <td>{ fileSize(file.size) }</td>
       </tr>
     );
-  },
-  render: function() {
+  };
+
+  render() {
     return (
       <table className='table table-striped table-bordered'>
         <thead>
@@ -50,11 +53,12 @@ const FormioFileList = React.createClass({
       </table>
     );
   }
-});
+}
 
-const FormioImageList = React.createClass({
-  displayName: 'FormioImageList',
-  render: function() {
+class FormioImageList extends React.Component {
+  static displayName = 'FormioImageList';
+
+  render() {
     return <div>
       {
         this.props.files ? this.props.files.map((file, index) => {
@@ -74,11 +78,12 @@ const FormioImageList = React.createClass({
       }
     </div>
   }
-});
+}
 
-const FormioFile = React.createClass({
-  displayName: 'FormioFile',
-  getFile: function(event) {
+class FormioFile extends React.Component {
+  static displayName = 'FormioFile';
+
+  getFile = (event) => {
     event.preventDefault();
     this.props.formio
        .downloadFile(this.props.file).then(file => {
@@ -91,20 +96,21 @@ const FormioFile = React.createClass({
         // User is expecting an immediate notification due to attempting to download a file.
         alert(response);
       });
-  },
-  render: function() {
+  };
+
+  render() {
     return <a href={this.props.file.url} onClick={event => {this.getFile(event)}} target="_blank">{this.props.file.name}</a>;
   }
-});
+}
 
-const FormioImage = React.createClass({
-  displayName: 'FormioImage',
-  getInitialState: function() {
-    return {
-      imageSrc: ''
-    }
-  },
-  componentWillMount: function() {
+class FormioImage extends React.Component {
+  static displayName = 'FormioImage';
+
+  state = {
+    imageSrc: ''
+  };
+
+  componentWillMount() {
     this.props.formio
       .downloadFile(this.props.file)
         .then(result => {
@@ -112,13 +118,14 @@ const FormioImage = React.createClass({
             imageSrc: result.url
           });
         });
-  },
-  render: function() {
+  }
+
+  render() {
     return <img src={this.state.imageSrc} alt={this.props.file.name} style={{width: this.props.width}} />;
   }
-});
+}
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'File',
   mixins: [valueMixin, componentMixin],
   getInitialValue: function() {

--- a/src/components/FormComponents/hidden.jsx
+++ b/src/components/FormComponents/hidden.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   mixins: [valueMixin, componentMixin],
   displayName: 'Hidden',
   getElements: function() {

--- a/src/components/FormComponents/htmlelement.jsx
+++ b/src/components/FormComponents/htmlelement.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'HtmlElement',
   mixins: [componentMixin],
   render: function (value, index) {

--- a/src/components/FormComponents/mixins/selectMixin.jsx
+++ b/src/components/FormComponents/mixins/selectMixin.jsx
@@ -106,8 +106,8 @@ module.exports = {
       }
     }
 
-    return React.createClass({
-      render: function() {
+    return class extends React.Component {
+      render() {
         let { item } = this.props;
         if (component.dataSrc === 'values') {
           // Search for the full item from values.
@@ -124,7 +124,7 @@ module.exports = {
 
         return React.createElement('span', {}, item);
       }
-    });
+    };
   },
   listComponent: function() {
     var root = this;

--- a/src/components/FormComponents/number.jsx
+++ b/src/components/FormComponents/number.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import inputMixin from './mixins/inputMixin';
 import multiMixin from './mixins/multiMixin';
@@ -6,7 +6,7 @@ import componentMixin from './mixins/componentMixin';
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import _repeat from 'lodash/repeat';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Number',
   mixins: [valueMixin, multiMixin, componentMixin, inputMixin],
   onChangeCustom: function(value) {

--- a/src/components/FormComponents/panel.jsx
+++ b/src/components/FormComponents/panel.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormioComponentsList } from '../../components';
 
-module.exports = React.createClass({
-  displayName: 'Panel',
-  render: function() {
+module.exports = class extends React.Component {
+  static displayName = 'Panel';
+
+  render() {
     var title = (this.props.component.title ? <div className='panel-heading'><h3 className='panel-title'>{this.props.component.title}</h3></div> : '');
     var className = 'panel panel-' + this.props.component.theme + ' ' + (this.props.component.customClass ? this.props.component.customClass : '');
     return (
@@ -18,4 +19,4 @@ module.exports = React.createClass({
       </div>
     );
   }
-});
+};

--- a/src/components/FormComponents/password.jsx
+++ b/src/components/FormComponents/password.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import inputMixin from './mixins/inputMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Password',
   mixins: [valueMixin, multiMixin, inputMixin, componentMixin]
 });

--- a/src/components/FormComponents/phoneNumber.jsx
+++ b/src/components/FormComponents/phoneNumber.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import inputMixin from './mixins/inputMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'PhoneNumber',
   mixins: [valueMixin, multiMixin, inputMixin, componentMixin]
 });

--- a/src/components/FormComponents/radio.jsx
+++ b/src/components/FormComponents/radio.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Radio',
   mixins: [valueMixin, multiMixin, componentMixin],
   onChangeRadio: function(event) {

--- a/src/components/FormComponents/resource.jsx
+++ b/src/components/FormComponents/resource.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import selectMixin from './mixins/selectMixin';
 import componentMixin from './mixins/componentMixin';
 import { raw, interpolate } from '../../util';
 import Formiojs from 'formiojs';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Resource',
   mixins: [valueMixin, selectMixin, componentMixin],
   componentWillMount: function() {

--- a/src/components/FormComponents/select.jsx
+++ b/src/components/FormComponents/select.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import selectMixin from './mixins/selectMixin';
 import componentMixin from './mixins/componentMixin';
@@ -7,7 +8,7 @@ import { interpolate, serialize, raw } from '../../util';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   options: {},
   lastInput: '',
   displayName: 'Select',

--- a/src/components/FormComponents/selectboxes.jsx
+++ b/src/components/FormComponents/selectboxes.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import componentMixin from './mixins/componentMixin';
 import clone from 'lodash/clone';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'SelectBox',
   mixins: [valueMixin, componentMixin],
   getInitialValue: function() {

--- a/src/components/FormComponents/signature.jsx
+++ b/src/components/FormComponents/signature.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import componentMixin from './mixins/componentMixin';
 import SignatureCanvas from 'react-signature-canvas';
 import _ from 'lodash';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Signature',
   mixins: [valueMixin, componentMixin],
   onEnd: function() {

--- a/src/components/FormComponents/survey.jsx
+++ b/src/components/FormComponents/survey.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Survey',
   mixins: [valueMixin, componentMixin],
   getInitialValue: function() {

--- a/src/components/FormComponents/table.jsx
+++ b/src/components/FormComponents/table.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormioComponentsList } from '../../components';
 
-module.exports = React.createClass({
-  displayName: 'Panel',
-  render: function() {
+module.exports = class extends React.Component {
+  static displayName = 'Panel';
+
+  render() {
     var title = (this.props.component.title ? <div className="panel-heading"><h3 className="panel-title">{this.props.component.title}</h3></div> : '');
     var tableClasses = 'table';
     tableClasses += (this.props.component.striped) ? ' table-striped' : '';
@@ -44,4 +45,4 @@ module.exports = React.createClass({
       </div>
     );
   }
-});
+};

--- a/src/components/FormComponents/textarea.jsx
+++ b/src/components/FormComponents/textarea.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactQuill from 'react-quill';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Textarea',
   mixins: [valueMixin, multiMixin, componentMixin],
   customState: function(state) {

--- a/src/components/FormComponents/textfield.jsx
+++ b/src/components/FormComponents/textfield.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import inputMixin from './mixins/inputMixin';
 import componentMixin from './mixins/componentMixin';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Textfield',
   mixins: [valueMixin, multiMixin, inputMixin, componentMixin]
 });

--- a/src/components/FormComponents/time.js
+++ b/src/components/FormComponents/time.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import valueMixin from './mixins/valueMixin';
 import multiMixin from './mixins/multiMixin';
 import componentMixin from './mixins/componentMixin';
 import moment from 'moment';
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'Time',
   mixins: [valueMixin, multiMixin, componentMixin],
   customState: function(state) {

--- a/src/components/FormComponents/well.jsx
+++ b/src/components/FormComponents/well.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormioComponentsList } from '../../components';
 
-module.exports = React.createClass({
-  displayName: 'Well',
-  render: function() {
+module.exports = class extends React.Component {
+  static displayName = 'Well';
+
+  render() {
     return (
       <div className="well">
         <FormioComponentsList
@@ -13,4 +14,4 @@ module.exports = React.createClass({
       </div>
     );
   }
-});
+};

--- a/src/components/Formio.jsx
+++ b/src/components/Formio.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Formiojs from 'formiojs';
 import FormioUtils from 'formio-utils';
 import { FormioComponentsList } from '../components';
@@ -7,7 +8,7 @@ import clone from 'lodash/clone';
 // TODO: We should have a better way of initializing form components.
 import '../components/FormComponents';
 
-export const Formio = React.createClass({
+export const Formio = createReactClass({
   displayName: 'Formio',
   getInitialState: function() {
     this.unmounting = false;


### PR DESCRIPTION
Fixes #234 

## Steps taken

1. In Windows 10, issued the following command in a Git Bash shell:
`jscodeshift --verbose=2 --ignore-pattern=*.spec.js --extensions=js,jsx --no-babel --parser=babel --transform /path/to/react-codemod/transforms/class.js src`


   <details>
   <summary>Output...</summary>
   <p>

   ```console
   Processing 51 files...
   Spawning 7 workers...
   Sending 8 files to free worker...
   Sending 8 files to free worker...
   Sending 8 files to free worker...
   Sending 8 files to free worker...
   Sending 8 files to free worker...
   Sending 8 files to free worker...
   Sending 3 files to free worker...
   src\components\FormComponents\password.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\email.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\phoneNumber.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\address.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\resource.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\container.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\textfield.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\button.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\hidden.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\currency.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\time.js: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\checkbox.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\number.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\select.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\htmlelement.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\textarea.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\datetime.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\selectboxes.jsx: `` was skipped because of inconvertible mixins.
   OKK src\components\FormComponents\address.jsx
   OKK src\components\index.js
   OKK src\factories\index.js
   OKK src\factories\FormioComponents.jsx
   OKK src\components\FormComponents\button.jsx
   src\components\FormComponents\signature.jsx: `` was skipped because of inconvertible mixins.
   OKK src\util\index.js
   src\components\Formio.jsx: `Formio` was skipped because `arguments` was found in your functions. Arrow functions do not expose an    `arguments` object; consider changing to use ES6 spread operator and re-run this script.
   src\components\FormComponents\file.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\survey.jsx: `` was skipped because of inconvertible mixins.
   OKK src\components\FormComponents\checkbox.jsx
   OKK src\components\FormComponents\columns.jsx
   OKK src\components\FormComponents\table.jsx
   OKK src\components\FormComponents\well.jsx
   OKK src\components\FormComponents\textfield.jsx
   OKK src\components\FormComponents\time.js
   OKK src\components\FormComponents\mixins\componentMixin.jsx
   OKK src\components\FormComponents\mixins\inputMixin.jsx
   src\components\FormComponents\datagrid.jsx: `` was skipped because of inconvertible mixins.
   OKK src\components\FormComponents\mixins\index.jsx
   OKK src\components\FormComponents\textarea.jsx
   src\components\FormComponents\radio.jsx: `` was skipped because of inconvertible mixins.
   OKK src\components\FormComponents\mixins\multiMixin.jsx
   OKK src\components\FormComponents\mixins\valueMixin.jsx
   OKK src\components\FormComponents\mixins\selectMixin.jsx
   src\components\FormComponents\editgrid.js: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\custom.jsx: `` was skipped because of inconvertible mixins.
   OKK src\components\FormComponents\email.jsx
   OKK src\components\FormComponents\fieldset.jsx
   OKK src\components\FormComponents\select.jsx
   OKK src\components\FormComponents\file.jsx
   OKK src\components\FormComponents\hidden.jsx
   OKK src\components\FormComponents\index.js
   OKK src\components\FormComponents\htmlelement.jsx
   OKK src\components\FormComponents\number.jsx
   OKK src\components\FormComponents\password.jsx
   OKK src\components\FormComponents\phoneNumber.jsx
   src\components\FormComponents\day.jsx: `` was skipped because of inconvertible mixins.
   src\components\FormComponents\content.jsx: `` was skipped because of inconvertible mixins.
   OKK src\components\FormComponents\resource.jsx
   OKK src\components\Formio.jsx
   OKK src\components\FormioComponentsList.jsx
   OKK src\components\FormComponents\selectboxes.jsx
   OKK src\components\FormBuilder.jsx
   OKK src\components\FormEdit.jsx
   OKK src\components\FormioGrid.jsx
   OKK src\index.js
   OKK src\components\FormComponents\panel.jsx
   OKK src\components\FormComponents\signature.jsx
   OKK src\components\FormComponents\radio.jsx
   OKK src\components\FormComponents\survey.jsx
   OKK src\components\Paginator.jsx
   OKK src\components\FormioConfirm.jsx
   OKK src\components\FormComponents\currency.jsx
   OKK src\components\FormComponents\datagrid.jsx
   OKK src\components\FormComponents\datetime.jsx
   OKK src\components\FormComponents\container.jsx
   OKK src\components\FormComponents\editgrid.js
   OKK src\components\FormComponents\day.jsx
   OKK src\components\FormComponents\content.jsx
   OKK src\components\FormComponents\custom.jsx
   All done.
   Results:
   0 errors
   0 unmodified
   0 skipped
   51 ok
   Time elapsed: 2.826seconds
   ```

   </p>
   </details>

1. Converted the line endings on the generated files from CRLF to LF.
   ```console
   find src -name "*.js" | xargs dos2unix
   find src -name "*.jsx" | xargs dos2unix
   ```
1. Ran `npm run build` to generate the transpiled files inside the `lib` folder.

1. Installed `create-react-class` as a production dependency via npm.