### PR TITLE
fix: Retrieve component props when form change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 bower_components
 lib
+.idea

--- a/src/components/FormBuilder.jsx
+++ b/src/components/FormBuilder.jsx
@@ -2,13 +2,14 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import AllComponents from 'formiojs/components';
 import Components from 'formiojs/components/Components';
-Components.setComponents(AllComponents);
 import FormioFormBuilder from 'formiojs/FormBuilder';
+
+Components.setComponents(AllComponents);
 
 export default class FormBuilder extends Component {
   static defaultProps = {
     options: {},
-    Builder: FormioFormBuilder,
+    Builder: FormioFormBuilder
   };
 
   static propTypes = {
@@ -19,7 +20,7 @@ export default class FormBuilder extends Component {
     onDeleteComponent: PropTypes.func,
     onCancelComponent: PropTypes.func,
     onEditComponent: PropTypes.func,
-    Builder: PropTypes.any,
+    Builder: PropTypes.any
   };
 
   componentDidMount = () => {
@@ -76,7 +77,7 @@ export default class FormBuilder extends Component {
 
   onChange = () => {
     if (this.props.hasOwnProperty('onChange') && typeof this.props.onChange === 'function') {
-      this.props.onChange(this.builder.instance.schema);
+      this.props.onChange(this.builder.instance.form);
     }
   };
 


### PR DESCRIPTION
When we edit an existing form, all props set for each components are removed (for example id is strip from component).
It comes an unexpected behavior when we use component.id as key (react component) to generate form in application.

Before fix:
```json
{
  "_id": "5d64f2e52326671f40b5b763",
  "type": "form",
  "tags": [
    "common"
  ],
  "owner": "5d2b606ed82bbfbdb5026c6d",
  "components": [
    {
      "label": "Text Field",
      "key": "textField",
}
```
after fix:
```jsonc
{
  "_id": "5d64f2e52326671f40b5b763",
  "type": "form",
  "tags": [
    "common"
  ],
  "owner": "5d2b606ed82bbfbdb5026c6d",
  "components": [
    {
      "label": "Text Field",
      "labelPosition": "top",
      "placeholder": "",
      "description": "",
      "tooltip": "",
      "prefix": "",
      "suffix": "",
      "widget": {
        "type": "input"
      },
      "inputMask": "",
      "allowMultipleMasks": false,
      // etc...
     "id": "efefje"
}
```

See you