### PR TITLE
Combine the query in store with getSubmissions argument

### DIFF
--- a/src/modules/submissions/actions.js
+++ b/src/modules/submissions/actions.js
@@ -39,7 +39,7 @@ export const getSubmissions = (name, page = 0, params = {}, formId, done = () =>
     sort,
   } = selectRoot(name, getState());
   const formio = new Formiojs(`${Formiojs.getProjectUrl()}/${(formId ? `form/${formId}` : name)}/submission`);
-  const requestParams = {...query};
+  const requestParams = {...query, ...params};
 
   // Ten is the default so if set to 10, don't send.
   if (limit !== 10) {


### PR DESCRIPTION
Fixes #242 by allowing to configure some 'static' parts of the query
when initialising the store and some 'dynamic' parts during dispatch
of `getSubmissions`.