### PR TITLE
Fix FormBuilder's onChange and onDeleteComponent not being called

### DIFF
--- a/src/components/FormBuilder.jsx
+++ b/src/components/FormBuilder.jsx
@@ -50,6 +50,7 @@ export default class FormBuilder extends Component {
       this.builder.instance.on('removeComponent', this.emit('onDeleteComponent'));
       this.builder.instance.on('cancelComponent', this.emit('onCancelComponent'));
       this.builder.instance.on('editComponent', this.emit('onEditComponent'));
+      this.builder.instance.on('addComponent', this.onChange);
       this.builder.instance.on('saveComponent', this.onChange);
       this.builder.instance.on('updateComponent', this.onChange);
       this.builder.instance.on('removeComponent', this.onChange);

--- a/src/components/FormBuilder.jsx
+++ b/src/components/FormBuilder.jsx
@@ -47,12 +47,12 @@ export default class FormBuilder extends Component {
     this.builderReady.then(() => {
       this.builder.instance.on('saveComponent', this.emit('onSaveComponent'));
       this.builder.instance.on('updateComponent', this.emit('onUpdateComponent'));
-      this.builder.instance.on('deleteComponent', this.emit('onDeleteComponent'));
+      this.builder.instance.on('removeComponent', this.emit('onDeleteComponent'));
       this.builder.instance.on('cancelComponent', this.emit('onCancelComponent'));
       this.builder.instance.on('editComponent', this.emit('onEditComponent'));
       this.builder.instance.on('saveComponent', this.onChange);
       this.builder.instance.on('updateComponent', this.onChange);
-      this.builder.instance.on('deleteComponent', this.onChange);
+      this.builder.instance.on('removeComponent', this.onChange);
     });
   };
 


### PR DESCRIPTION
The previous attempt (#216) to fix #198 is being overwritten in fad22d8be15291a7a27a9bf8ca386c1da0caa4ba.

In addition to #216, this PR also fixes `onDeleteComponent` not being called.